### PR TITLE
Add type hints and docs

### DIFF
--- a/pyturbseq/cellranger.py
+++ b/pyturbseq/cellranger.py
@@ -12,18 +12,25 @@ import math
 from .utils import add_pattern_to_adata
 
 
+from typing import Optional, Dict, Any
+
+
 def parse_CR_h5(
-    cellranger_h5_path,
-    guide_call_csv=None,
-    pattern=None,
-    quiet=False,
-    ):
-    """
-    Read in 10x data from a CRISPR screen.
-    Args: 
-        CR_out: path to the output directory of the CRISPR screen
-        pattern: regex pattern to extract metadata from the file name
-        add_guide_calls: whether to add guide calls to the adata.obs
+    cellranger_h5_path: str,
+    guide_call_csv: Optional[str] = None,
+    pattern: Optional[str] = None,
+    quiet: bool = False,
+) -> sc.AnnData:
+    """Read in 10x data from a CRISPR screen.
+
+    Args:
+        cellranger_h5_path: Path to the ``filtered_feature_bc_matrix.h5`` file.
+        guide_call_csv: Optional path to a guide call ``.csv`` file.
+        pattern: Regex pattern used to extract metadata from ``cellranger_h5_path``.
+        quiet: If ``True`` suppresses printed output.
+
+    Returns:
+        AnnData object with optional guide call annotations.
     """
     vp = print if not quiet else lambda *a, **k: None
 
@@ -62,43 +69,65 @@ def parse_CR_h5(
 
     return(adata)
 
-def parse_umi(x):
-    """
-    Parse the output of the CRISPR analysis from cellranger pipeline to get the total number of UMIs and the max UMI
+def parse_umi(x: Any) -> Dict[str, float]:
+    """Parse ``num_umis`` field from the Cellranger output.
+
+    Args:
+        x: Value from the ``num_umis`` column. Can be a float or pipe delimited
+            string of UMI counts.
+
+    Returns:
+        Dictionary with total UMIs, maximum UMI, and ratio of the second highest
+        to the highest UMI count.
     """
     if isinstance(x, float):
         return {
-            'CR_total_umi': x,
-            'CR_max_umi': x,
-            'CR_ratio_2nd_1st': math.nan
+            "CR_total_umi": x,
+            "CR_max_umi": x,
+            "CR_ratio_2nd_1st": math.nan,
         }
-    split = [int(i) for i in x.split('|')]
+    split = [int(i) for i in x.split("|")]
     split.sort(reverse=True)
     m = {
-        'CR_total_umi': sum(split),
-        'CR_max_umi': split[0],
-        'CR_ratio_2nd_1st': math.nan if len(split) == 1 else split[1]/split[0]
+        "CR_total_umi": sum(split),
+        "CR_max_umi": split[0],
+        "CR_ratio_2nd_1st": math.nan if len(split) == 1 else split[1] / split[0],
     }
     return m
 
-def add_CR_umi_metrics(adata):
+def add_CR_umi_metrics(adata: sc.AnnData) -> sc.AnnData:
+    """Add CRISPR UMI metrics to ``adata.obs``.
+
+    Args:
+        adata: AnnData object returned by :func:`parse_CR_h5`.
+
+    Returns:
+        The modified AnnData object with additional columns ``CR_total_umi``,
+        ``CR_max_umi`` and ``CR_ratio_2nd_1st`` added to ``adata.obs``.
     """
-    Add the CRISPR UMI metrics to the adata.obs
-    """
-    df = pd.DataFrame([parse_umi(x) for x in adata.obs['num_umis']], index=adata.obs.index)
-    #merge by index but keep index as index
+    df = pd.DataFrame([parse_umi(x) for x in adata.obs["num_umis"]], index=adata.obs.index)
+    # merge by index but keep index as index
     adata.obs = adata.obs.merge(df, left_index=True, right_index=True)
     return adata
 
 def add_CR_sgRNA(
-    adata,
-    calls_file="protospacer_calls_per_cell.csv",
-    library_ref_file=None,
-    inplace=True,
-    quiet=False,
-    ):
-    """
-    Uses the cellranger calls and merges them with anndata along with some metrics
+    adata: sc.AnnData,
+    calls_file: str = "protospacer_calls_per_cell.csv",
+    library_ref_file: Optional[str] = None,
+    inplace: bool = True,
+    quiet: bool = False,
+) -> Optional[sc.AnnData]:
+    """Merge sgRNA calls from Cellranger output into ``adata``.
+
+    Args:
+        adata: AnnData object to annotate.
+        calls_file: CSV file produced by Cellranger ``protospacer_calls_per_cell.csv``.
+        library_ref_file: Optional reference file for sgRNA library (unused currently).
+        inplace: If ``True`` modify ``adata`` in place.
+        quiet: If ``True`` suppresses printed output.
+
+    Returns:
+        Optionally returns a new AnnData object if ``inplace`` is ``False``.
     """
     #confirm that calls_file exists
     if not os.path.exists(calls_file):
@@ -119,7 +148,16 @@ def add_CR_sgRNA(
         return adata
 
 
-def parse_CR_flex_metrics(df):
+def parse_CR_flex_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize metric values from Cellranger FLEX output.
+
+    Args:
+        df: DataFrame as read from ``metrics_summary.csv``.
+
+    Returns:
+        DataFrame with numeric ``Metric Value`` column converted to floats.
+    """
+
     df = df.copy()
     #formatted like so: 40.00%
     pct_fmt = df['Metric Value'].str.endswith('%', na=False)

--- a/pyturbseq/de.py
+++ b/pyturbseq/de.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import Iterable, Optional, List
 from tqdm import tqdm
 import pandas as pd
 from pydeseq2.dds import DeseqDataSet
@@ -12,19 +13,28 @@ import math
 from joblib import Parallel, delayed
 
 
-def get_degs(adata, design_col, covariate_cols=None, ref_val=None, alpha=0.05, n_cpus=16, quiet=False):
-    """
-    Run DESeq2 analysis on single-cell RNA sequencing data.
-    
-    Parameters:
-    adata (AnnData): AnnData object containing the single-cell RNA-seq data.
-    design_col (str): Column name in adata.obs that contains the design matrix.
-    ref_val (str, optional): Reference value for the design matrix. Defaults to None.
-    n_cpus (int, optional): Number of CPUs to use for DESeq2. Defaults to 16.
-    quiet (bool, optional): Flag to suppress DESeq2 output. Defaults to True.
+def get_degs(
+    adata: "AnnData",
+    design_col: str,
+    covariate_cols: Optional[List[str]] = None,
+    ref_val: Optional[str] = None,
+    alpha: float = 0.05,
+    n_cpus: int = 16,
+    quiet: bool = False,
+) -> pd.DataFrame:
+    """Run DESeq2 differential expression for a single comparison.
+
+    Args:
+        adata: AnnData object containing counts.
+        design_col: Column in ``adata.obs`` describing the experimental design.
+        covariate_cols: Optional list of additional covariates.
+        ref_val: Reference value for ``design_col``.
+        alpha: Adjusted p-value cutoff for significance.
+        n_cpus: Number of CPUs used by pydeseq2.
+        quiet: Suppress verbose output when ``True``.
 
     Returns:
-    pd.DataFrame: DataFrame containing DESeq2 results.
+        DataFrame of DESeq2 results for the contrast.
     """
 
     ref_level = [design_col, ref_val] if ref_val is not None else None
@@ -64,21 +74,33 @@ def get_degs(adata, design_col, covariate_cols=None, ref_val=None, alpha=0.05, n
 
     return df
 
-def get_all_degs(adata, design_col, reference, conditions=None, parallel=True, n_cpus=8, max_workers=4, quiet=False, **kwargs):
-    """
-    Run DESeq2 analysis in parallel for multiple conditions.
+def get_all_degs(
+    adata: "AnnData",
+    design_col: str,
+    reference: str,
+    conditions: Optional[Iterable[str]] = None,
+    parallel: bool = True,
+    n_cpus: int = 8,
+    max_workers: int = 4,
+    quiet: bool = False,
+    **kwargs,
+) -> pd.DataFrame:
+    """Run DESeq2 for multiple conditions in parallel.
 
-    Parameters:
-    adata (AnnData): AnnData object containing the single-cell RNA-seq data.
-    design_col (str): Column name in adata.obs that contains the design matrix.
-    reference (str): Reference condition for the differential expression test.
-    conditions (list, optional): List of conditions to test against the reference. Defaults to None.
-    n_cpus (int, optional): Number of CPUs to use for each DESeq2 task. Defaults to 8.
-    max_workers (int, optional): Maximum number of parallel tasks. Defaults to 4.
-    quiet (bool, optional): Flag to suppress DESeq2 output. Defaults to False.
+    Args:
+        adata: AnnData object with count data.
+        design_col: Column used as the design factor.
+        reference: Reference condition within ``design_col``.
+        conditions: Specific conditions to test. If ``None`` all non-reference
+            values are tested.
+        parallel: Whether to run in parallel using joblib.
+        n_cpus: Number of CPUs per DESeq2 task.
+        max_workers: Maximum number of concurrent tasks.
+        quiet: Suppress verbose output.
+        **kwargs: Additional keyword arguments passed to :func:`get_degs`.
 
     Returns:
-    pd.DataFrame: Concatenated DataFrame containing results for all conditions.
+        Concatenated DataFrame of DESeq2 results for each condition.
     """
 
     vp = print if not quiet else lambda *a, **k: None

--- a/pyturbseq/guides.py
+++ b/pyturbseq/guides.py
@@ -3,17 +3,25 @@
 # Functions for QC of sgRNA (guide) libraries
 #
 ##########################################################################
+from typing import Iterable
 from scipy.spatial import distance
 from tqdm import tqdm
 import numpy as np
 
-def hamming_dist(a, b):
+def hamming_dist(a: str, b: str) -> float:
+    """Compute the normalized Hamming distance between two strings."""
     return distance.hamming(list(a), list(b))
 
-def hamming_dist_matrix(ref):
+def hamming_dist_matrix(ref: Iterable[str]) -> np.ndarray:
+    """Compute pairwise Hamming distance matrix for a collection of strings.
+
+    Args:
+        ref: Iterable of strings, all assumed to be equal length.
+
+    Returns:
+        A square NumPy array of pairwise Hamming distances.
     """
-    This method take a list of strings, assumed to all be the same length, and pairwise haming distance
-    """
+
     dists = np.zeros((len(ref), len(ref)))
 
     #get triangle upper indices

--- a/pyturbseq/utils.py
+++ b/pyturbseq/utils.py
@@ -131,17 +131,33 @@ def split_by_feature_type(
 ########################################################################################################################
 #read in the feature call column, split all of them by delimiter 
 def generate_perturbation_matrix(
-    adata,
-    perturbation_col = 'feature_call',
-    delim = '|',
-    reference_value = 'NTC',
-    feature_list = None,
-    keep_ref = False,
-    set_ref_1 = False,
-    return_boolean=True,
-    # sparse = True,
-    verbose = True,
-    ):
+    adata: AnnData,
+    perturbation_col: str = "feature_call",
+    delim: str = "|",
+    reference_value: str = "NTC",
+    feature_list: Optional[Iterable[str]] = None,
+    keep_ref: bool = False,
+    set_ref_1: bool = False,
+    return_boolean: bool = True,
+    verbose: bool = True,
+) -> pd.DataFrame:
+    """Generate a binary perturbation matrix from ``adata.obs``.
+
+    Args:
+        adata: AnnData object with a column describing perturbations.
+        perturbation_col: Column in ``adata.obs`` with perturbation calls.
+        delim: Delimiter separating multiple perturbations within a cell.
+        reference_value: Name of the reference perturbation.
+        feature_list: Optional list of perturbations to include.
+        keep_ref: Whether to keep the reference column in the output.
+        set_ref_1: If ``True`` and ``keep_ref`` is ``True`` set all reference
+            values to 1.
+        return_boolean: Return boolean matrix instead of integers.
+        verbose: Print progress messages.
+
+    Returns:
+        DataFrame where rows correspond to cells and columns to perturbations.
+    """
 
     #if there is no feature list, split all the features in the column and build one
     if feature_list is None:
@@ -185,20 +201,23 @@ def generate_perturbation_matrix(
         columns=feature_list)
 
 def get_perturbation_matrix(
-        adata, 
-        perturbation_col = 'feature_call',
-        inplace = True,    
-        **kwargs      
-        ):
-    """
-    Add a perturbation matrix to an anndata object. 
+    adata: AnnData,
+    perturbation_col: str = "feature_call",
+    inplace: bool = True,
+    **kwargs,
+) -> Optional[pd.DataFrame]:
+    """Add or return a perturbation matrix for ``adata``.
+
     Args:
-        adata: anndata object
-        perturbation_col: column in adata.obs that contains the perturbation information
-        feature_list: list of features to include in the perturbation matrix. If None, all features in the perturbation column will be included.
-        inplace: whether to add the perturbation matrix to the adata object or return it
+        adata: AnnData object to annotate.
+        perturbation_col: Column in ``adata.obs`` containing perturbation labels.
+        inplace: If ``True`` store the matrix in ``adata.obsm['perturbation']``.
+        **kwargs: Additional arguments forwarded to
+            :func:`generate_perturbation_matrix`.
+
     Returns:
-        adata object with perturbation matrix in adata.layers['perturbations']
+        If ``inplace`` is ``False`` the generated perturbation matrix is
+        returned as a DataFrame; otherwise ``None``.
     """
     pm = generate_perturbation_matrix(
             adata,


### PR DESCRIPTION
## Summary
- add type hints and detailed docstrings to `cellranger`, `guides`, `de`, and `utils`
- update function documentation with Args/Returns sections

## Testing
- `python -m compileall pyturbseq`